### PR TITLE
add activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "atom": ">=1.22.0 <2.0.0"
   },
   "activationCommands": {},
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "configSchema": {
     "keywordPairs": {
       "order": 1,

--- a/spec/keyword-pair-matcher-spec.js
+++ b/spec/keyword-pair-matcher-spec.js
@@ -13,6 +13,10 @@ function prepareEditor(name, text) {
 
 describe("keyword-pair-matcher", () => {
   beforeEach(() => {
+    // Package activation will be deferred to the configured, activation hook, which is then triggered
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
     waitsForPromise(() => atom.packages.activatePackage("keyword-pair-matcher"));
     atom.config.set(`${PKGNAME}.keywordPairs`, ["begin..end", "def..end", "do..done"]);
     atom.config.set(`${PKGNAME}.keywordCharacters`, "A-Za-z0-9_");


### PR DESCRIPTION
 This speeds up loading of Atom, by deferring the loading of the package until the core Atom shell is loaded. 